### PR TITLE
moved getbb(location) to the beginning of the function

### DIFF
--- a/R/make_sexy_map.r
+++ b/R/make_sexy_map.r
@@ -16,7 +16,9 @@ make_sexy_map<-function(location,short_name,monochrome = FALSE){
 
 
 print("Downloading Data")
-highway_data<-getbb(location)%>%
+
+bb<-getbb(location)
+highway_data<-bb%>%
   opq()%>%
   add_osm_feature(key = "highway") %>%
   osmdata_sf()
@@ -102,7 +104,6 @@ q<-p+pmap(
   ),
   plot_osm_lines)
 
-bb<-getbb(location)
 trim_x<-0.001
 trim_y <- 0.001
 


### PR DESCRIPTION
calling getbb(location) for the second time was causing curl to fail with the following error.

`Error in curl::curl_fetch_memory(url, handle = handle) :Error in the HTTP2 framing layer`

Moving the bb <- getbb(location) to the start of the function and refactoring the getbb(location) call from the highway_data assignment fixed this.
Although curl still chokes if I call make_sexy_map() repeatedly/quickly?